### PR TITLE
Fix parsing titles of restricted works

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -544,7 +544,7 @@ class Work:
 
         title = self._soup.find("div", {'class': 'preface group'})
         if title is not None:
-            return str(title.h2.string.strip())
+            return str(title.h2.text.strip())
         return ""
     
     @cached_property


### PR DESCRIPTION
Fix a bug that causes Work.title to throw an AttributeError exception when parsing the titles of restricted-but-accessible works.  