### PR TITLE
Revised PR for getting history pages

### DIFF
--- a/AO3/session.py
+++ b/AO3/session.py
@@ -331,13 +331,14 @@ class Session(GuestSession):
                 n = int(text)
         return n
 
-    def get_history(self, hist_sleep=0, max_pages=None, timeout_sleep=None):
+    def get_history(self, hist_sleep=0, start_page=0, max_pages=None, timeout_sleep=None):
         """
         Get history works. Loads them if they haven't been previously.
 
         Arguments:
           hist_sleep (int to sleep between requests)
-          max_pages  (int, maximum number of pages of history to request)
+          start_page (int for page to start on, zero-indexed)
+          max_pages  (int for page to end on, zero-indexed)
           timeout_sleep (int, if set will attempt to recovery from http errors, likely timeouts)
 
  takes two arguments the first hist_sleep is an int and is a sleep to run between pages of history to load to avoid hitting the rate limiter, the second is an int of the maximum number of pages of history to load, by default this is None so loads them all.
@@ -348,7 +349,7 @@ class Session(GuestSession):
         
         if self._history is None:
             self._history = []
-            for page in range(self._history_pages):
+            for page in range(start_page, self._history_pages):
                 # If we are attempting to recover from errors then
                 # catch and loop, otherwise just call and go
                 if timeout_sleep is None:
@@ -365,7 +366,7 @@ class Session(GuestSession):
                             time.sleep(timeout_sleep)
 
                 # Check for maximum history page load
-                if max_pages is not None and page+1 >= max_pages:
+                if max_pages is not None and page >= max_pages:
                     return self._history
 
                 # Again attempt to avoid rate limiter, sleep for a few

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 import re
 import datetime
+import time
 
 import requests
 from bs4 import BeautifulSoup
@@ -330,9 +331,9 @@ class Session(GuestSession):
                 n = int(text)
         return n
 
-    def get_history(self):
+    def get_history(self, hist_sleep=0, max_pages=None):
         """
-        Get history works. Loads them if they haven't been previously
+        Get history works. Loads them if they haven't been previously, takes two arguments the first hist_sleep is an int and is a sleep to run between pages of history to load to avoid hitting the rate limiter, the second is an int of the maximum number of pages of history to load, by default this is None so loads them all.
 
         Returns:
             list: List of tuples (Work, number-of-visits, datetime-last-visited)
@@ -342,6 +343,9 @@ class Session(GuestSession):
             self._history = []
             for page in range(self._history_pages):
                 self._load_history(page=page+1)
+                if max_pages is not None and page+1 >= max_pages:
+                    return self._history
+                time.sleep(hist_sleep)
         return self._history
 
     def _load_history(self, page=1):       

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -358,9 +358,10 @@ class Session(GuestSession):
                     while loaded == False:
                         try:
                             self._load_history(page=page+1)
+                            print(f"Read history page {page+1}")
                             loaded = True
                         except utils.HTTPError:
-                            #print("session.py being rate limited, sleeping")
+                            print(f"History being rate limited, sleeping for {timeout_sleep} seconds")
                             time.sleep(timeout_sleep)
 
                 # Check for maximum history page load

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -331,9 +331,16 @@ class Session(GuestSession):
                 n = int(text)
         return n
 
-    def get_history(self, hist_sleep=0, max_pages=None):
+    def get_history(self, hist_sleep=0, max_pages=None, timeout_sleep=None):
         """
-        Get history works. Loads them if they haven't been previously, takes two arguments the first hist_sleep is an int and is a sleep to run between pages of history to load to avoid hitting the rate limiter, the second is an int of the maximum number of pages of history to load, by default this is None so loads them all.
+        Get history works. Loads them if they haven't been previously.
+
+        Arguments:
+          hist_sleep (int to sleep between requests)
+          max_pages  (int, maximum number of pages of history to request)
+          timeout_sleep (int, if set will attempt to recovery from http errors, likely timeouts)
+
+ takes two arguments the first hist_sleep is an int and is a sleep to run between pages of history to load to avoid hitting the rate limiter, the second is an int of the maximum number of pages of history to load, by default this is None so loads them all.
 
         Returns:
             list: List of tuples (Work, number-of-visits, datetime-last-visited)
@@ -342,9 +349,25 @@ class Session(GuestSession):
         if self._history is None:
             self._history = []
             for page in range(self._history_pages):
-                self._load_history(page=page+1)
+                # If we are attempting to recover from errors then
+                # catch and loop, otherwise just call and go
+                if timeout_sleep is None:
+                    self._load_history(page=page+1)
+                else:
+                    loaded=False
+                    while loaded == False:
+                        try:
+                            self._load_history(page=page+1)
+                            loaded = True
+                        except AO3.utils.HTTPError:
+                            time.sleep(timeout_sleep)
+
+                # Check for maximum history page load
                 if max_pages is not None and page+1 >= max_pages:
                     return self._history
+
+                # Again attempt to avoid rate limiter, sleep for a few
+                # seconds between page requests.
                 time.sleep(hist_sleep)
         return self._history
 

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -349,7 +349,6 @@ class Session(GuestSession):
         soup = self.request(url)
         history = soup.find("ol", {'class': 'reading work index group'})
         for item in history.find_all("li", {'class': 'reading work blurb group'}):
-            # print(item)
             authors = []
             for a in item.h4.find_all("a"):
                 if 'rel' in a.attrs.keys():
@@ -359,10 +358,9 @@ class Session(GuestSession):
                     workname = str(a.string)
                     workid = utils.workid_from_url(a['href'])
 
-            visited_date = ""
+            visited_date = None
             visited_num = 1
             for viewed in item.find_all("h4", {'class': "viewed heading" }):
-                # print(type(viewed))
                 data_string = str(viewed)
                 date_str = re.search('<span>Last visited:</span> (\d{2} .+ \d{4})', data_string)
                 if date_str is not None:

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -331,7 +331,7 @@ class Session(GuestSession):
                 n = int(text)
         return n
 
-    def get_history(self, hist_sleep=0, start_page=0, max_pages=None, timeout_sleep=None):
+    def get_history(self, hist_sleep=3, start_page=0, max_pages=None, timeout_sleep=60):
         """
         Get history works. Loads them if they haven't been previously.
 
@@ -339,7 +339,7 @@ class Session(GuestSession):
           hist_sleep (int to sleep between requests)
           start_page (int for page to start on, zero-indexed)
           max_pages  (int for page to end on, zero-indexed)
-          timeout_sleep (int, if set will attempt to recovery from http errors, likely timeouts)
+          timeout_sleep (int, if set will attempt to recovery from http errors, likely timeouts, if set to None will just attempt to load)
 
  takes two arguments the first hist_sleep is an int and is a sleep to run between pages of history to load to avoid hitting the rate limiter, the second is an int of the maximum number of pages of history to load, by default this is None so loads them all.
 
@@ -354,6 +354,7 @@ class Session(GuestSession):
                 # catch and loop, otherwise just call and go
                 if timeout_sleep is None:
                     self._load_history(page=page+1)
+                    
                 else:
                     loaded=False
                     while loaded == False:
@@ -361,6 +362,7 @@ class Session(GuestSession):
                             self._load_history(page=page+1)
                             print(f"Read history page {page+1}")
                             loaded = True
+
                         except utils.HTTPError:
                             print(f"History being rate limited, sleeping for {timeout_sleep} seconds")
                             time.sleep(timeout_sleep)
@@ -371,7 +373,9 @@ class Session(GuestSession):
 
                 # Again attempt to avoid rate limiter, sleep for a few
                 # seconds between page requests.
-                time.sleep(hist_sleep)
+                if hist_sleep is not None and hist_sleep > 0:
+                    time.sleep(hist_sleep)
+
         return self._history
 
     def _load_history(self, page=1):       

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -359,7 +359,8 @@ class Session(GuestSession):
                         try:
                             self._load_history(page=page+1)
                             loaded = True
-                        except AO3.utils.HTTPError:
+                        except utils.HTTPError:
+                            #print("session.py being rate limited, sleeping")
                             time.sleep(timeout_sleep)
 
                 # Check for maximum history page load

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -360,11 +360,11 @@ class Session(GuestSession):
                     while loaded == False:
                         try:
                             self._load_history(page=page+1)
-                            print(f"Read history page {page+1}")
+                            # print(f"Read history page {page+1}")
                             loaded = True
 
                         except utils.HTTPError:
-                            print(f"History being rate limited, sleeping for {timeout_sleep} seconds")
+                            # print(f"History being rate limited, sleeping for {timeout_sleep} seconds")
                             time.sleep(timeout_sleep)
 
                 # Check for maximum history page load

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -353,12 +353,11 @@ class Session(GuestSession):
         soup = self.request(url)
         history = soup.find("ol", {'class': 'reading work index group'})
         for item in history.find_all("li", {'class': 'reading work blurb group'}):
-            authors = []
+            # authors = []
+            workname = None
+            workid = None
             for a in item.h4.find_all("a"):
-                if 'rel' in a.attrs.keys():
-                    if "author" in a['rel']:
-                        authors.append(User(str(a.string), load=False))
-                elif a.attrs["href"].startswith("/works"):
+                if a.attrs["href"].startswith("/works"):
                     workname = str(a.string)
                     workid = utils.workid_from_url(a['href'])
 
@@ -376,14 +375,15 @@ class Session(GuestSession):
                 if visited_str is not None:
                     visited_num = int(visited_str.group(1))
                 
-            
-            new = Work(workid, load=False)
-            setattr(new, "title", workname)
-            setattr(new, "authors", authors)
-            hist_item = [ new, visited_num, visited_date ]
-            # print(hist_item)
-            if new not in self._history:
-                self._history.append(hist_item)
+
+            if workname != None and workid != None:
+                new = Work(workid, load=False)
+                setattr(new, "title", workname)
+                # setattr(new, "authors", authors)
+                hist_item = [ new, visited_num, visited_date ]
+                # print(hist_item)
+                if new not in self._history:
+                    self._history.append(hist_item)
                 
     @cached_property
     def _bookmark_pages(self):

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -335,7 +335,7 @@ class Session(GuestSession):
         Get history works. Loads them if they haven't been previously
 
         Returns:
-            list: List of tuples (workid, workname, authors)
+            list: List of tuples (Work, number-of-visits, datetime-last-visited)
         """
         
         if self._history is None:


### PR DESCRIPTION
Should now be able to pull history pages accurately, also due to the volume of pages in many peoples histories has some delays and retrying built in (I have ideas for maybe another PR to put in rate limit recovery at a more general library level later but this will do for now)