### PR TITLE
Expand the function description to download a file

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -147,6 +147,7 @@ class Work:
 
         Args:
             filetype (str, optional): Desired filetype. Defaults to "PDF".
+            Known filetypes are: AZW3, EPUB, HTML, MOBI, PDF. 
 
         Raises:
             utils.DownloadError: Raised if there was an error with the download
@@ -178,6 +179,7 @@ class Work:
         Args:
             filename (str): Name of the resulting file
             filetype (str, optional): Desired filetype. Defaults to "PDF".
+            Known filetypes are: AZW3, EPUB, HTML, MOBI, PDF.
 
         Raises:
             utils.DownloadError: Raised if there was an error with the download


### PR DESCRIPTION
The options listed are the ones I know about, as they are shown on the website and have listed them alphabetically.

I tested downloading each of the filetypes and successfully did so. 
I haven't tested seeing if the AZW3, EPUB and MOBI files open, as I don't have a application/device to open then with.
I did try to see if downloading as a .txt file was possible, but didn't have much luck.

If this doesn't match your style quite right, please let me know what I can do to bring it in line.
Thanks