### PR TITLE
Copy changes from README

### DIFF
--- a/docs/use.md
+++ b/docs/use.md
@@ -8,7 +8,7 @@ One of the most basic things you might want to do with this package is loading a
 
 We start by finding the _workid_ of the work we want to load. We do that either by using `AO3.utils.workid_from_url(url)` or by just looking at the url ourselves. Let's take a look:
 
-```python
+```py3
 import AO3
 
 url = "https://archiveofourown.org/works/14392692/chapters/33236241"
@@ -20,14 +20,14 @@ print(f"Chapters: {work.nchapters}")
 
 After running this snippet, we get the output:
 
-
-    Work ID: 14392692
-    Chapters: 46
-
+```
+Work ID: 14392692
+Chapters: 46
+```
 
 It's important to note that some works may not be accessible to guest users, and in this case you will get 0 chapters as an output, and the error `AO3.utils.AuthError: This work is only available to registered users of the Archive` if you try to load it. Nontheless, we can still do a lot more with this Work object: Lets try to get the first 20 words of the second chapter.
 
-```python
+```py3
 import AO3
 
 work = AO3.Work(14392692)
@@ -37,20 +37,20 @@ text = work.chapters[1].text  # Second chapter text
 print(' '.join(text.split(" ")[:20]))
 ```
 
+```
+What Branches Grow Meaning
+December 27, 2018
 
-    What Branches Grow Meaning
-    December 27, 2018
-    
-    Christmas sucked this year, and Shouto’s got the black eye to prove it.
-    Things had started out well enough,
-
+Christmas sucked this year, and Shouto’s got the black eye to prove it.
+Things had started out well enough,
+```
 
 The objects in work.chapters are of type `AO3.Chapter`. They have a lot of the same properties as a `Work` object would.
 
 
-Another thing you can do with the work object is download the entire work as a pdf or e-book.
+Another thing you can do with the work object is download the entire work as a pdf or e-book. At the moment you can download works as AZW3, EPUB, HTML, MOBI, and PDF files.
 
-```python
+```py3
 import AO3
 
 work = AO3.Work(14392692)
@@ -64,7 +64,7 @@ __Advanced functionality__
 
 Usually, when you call the constructor for the `Work` class, all info about it is loaded in the `__init__()` function. However, this process takes quite some time (~1-1.5 seconds) and if you want to load a list of works from a series, for example, you might be waiting for upwards of 30 seconds. To avoid this problem, the `Work.reload()` function, called on initialization, is a "threadable" function, which means that if you call it with the argument `threaded=True`, it will return a `Thread` object and work in parallel, meaning you can load multiple works at the same time. Let's take a look at an implementation:
 
-```python
+```py3
 import AO3
 import time
 
@@ -81,11 +81,11 @@ for thread in threads:
 print(f"Loaded {len(works)} works in {round(time.time()-start, 1)} seconds.")
 ```
 
-    Loaded 29 works in 2.2 seconds.
+`Loaded 29 works in 2.2 seconds.`
 
 The `load=False` inside the `Work` constructor makes sure we don't load the work as soon as we create an instance of the class. In the end, we iterate over every thread and wait for the last one to finish using `.join()`. Let's compare this method with the standard way of loading AO3 works:
 
-```python
+```py3
 import AO3
 import time
 
@@ -100,7 +100,7 @@ for work in series.work_list:
 print(f"Loaded {len(works)} works in {round(time.time()-start, 1)} seconds.")
 ```
 
-    Loaded 29 works in 21.6 seconds.
+`Loaded 29 works in 21.6 seconds.`
 
 As we can see, there is a significant performance increase. There are other functions in this package which have this functionality. To see if a function is "threadable", either use `hasattr(function, "_threadable")` or check its `__doc__` string.
 
@@ -108,7 +108,7 @@ To save even more time, if you're only interested in metadata, you can load a wo
 
 The last important information about the `Work` class is that most of its properties (like the number of bookmarks, kudos, the authors' names, etc...) are cached properties. That means that once you check them once, the value is stored and it won't ever change, even if those values change. To update these values, you will need to call `Work.reload()`. See the example below:
 
-```python
+```py3
 import AO3
 
 sess = AO3.GuestSession()
@@ -119,10 +119,10 @@ work.reload()
 print(work.kudos)
 ```
 
-
-    392
-    393
-
+```
+392
+393
+```
 
 
 
@@ -130,7 +130,7 @@ print(work.kudos)
 
 Another useful thing you might want to do is get information on who wrote which works / comments. For that, we use the `AO3.User` class.
 
-```python
+```py3
 import AO3
 
 user = AO3.User("bothersomepotato")
@@ -139,18 +139,18 @@ print(user.bio)
 print(user.works)  # Number of works published
 ```
 
-
-    https://archiveofourown.org/users/bothersomepotato
-    University student, opening documents to write essays but writing this stuff instead. No regrets though. My Tumblr, come chat with -or yell at- me if you feel like it! :)
-    2
-
+```
+https://archiveofourown.org/users/bothersomepotato
+University student, opening documents to write essays but writing this stuff instead. No regrets though. My Tumblr, come chat with -or yell at- me if you feel like it! :)
+2
+```
 
 
 ## Search
 
 To search for works, you can either use the `AO3.search()` function and parse the BeautifulSoup object returned yourself, or use the `AO3.Search` class to automatically do that for you
 
-```python
+```py3
 import AO3
 search = AO3.Search(any_field="Clarke Lexa", word_count=AO3.utils.Constraint(5000, 15000))
 search.update()
@@ -159,32 +159,32 @@ for result in search.results:
   print(result)
 ```
 
-
-    3074
-    <Work [five times lexa falls for clarke]>
-    <Work [an incomplete list of reasons (why Clarke loves Lexa)]>
-    <Work [five times clarke and lexa aren’t sure if they're a couple or not]>
-    <Work [Chemistry]>
-    <Work [The New Commander (Lexa Joining Camp Jaha)]>
-    <Work [Ode to Clarke]>
-    <Work [it's always been (right in front of me)]>
-    <Work [The Girlfriend Tag]>
-    <Work [The After-Heda Chronicles]>
-    <Work [The Counter]>
-    <Work [May We Meet Again]>
-    <Work [No Filter]>
-    <Work [The Games We Play]>
-    <Work [A l'épreuve des balles]>
-    <Work [Celebration]>
-    <Work [Another level of fucked up]>
-    <Work [(Don't Ever Want to Tame) This Wild Heart]>
-    <Work [Self Control]>
-    <Work [Winter]>
-    <Work [My only wish]>
-
+```
+3074
+<Work [five times lexa falls for clarke]>
+<Work [an incomplete list of reasons (why Clarke loves Lexa)]>
+<Work [five times clarke and lexa aren’t sure if they're a couple or not]>
+<Work [Chemistry]>
+<Work [The New Commander (Lexa Joining Camp Jaha)]>
+<Work [Ode to Clarke]>
+<Work [it's always been (right in front of me)]>
+<Work [The Girlfriend Tag]>
+<Work [The After-Heda Chronicles]>
+<Work [The Counter]>
+<Work [May We Meet Again]>
+<Work [No Filter]>
+<Work [The Games We Play]>
+<Work [A l'épreuve des balles]>
+<Work [Celebration]>
+<Work [Another level of fucked up]>
+<Work [(Don't Ever Want to Tame) This Wild Heart]>
+<Work [Self Control]>
+<Work [Winter]>
+<Work [My only wish]>
+```
 
 You can then use the workid to load one of the works you searched for. To get more then the first 20 works, change the page number using 
-```python
+```py3
 search.page = 2
 ```
 
@@ -192,7 +192,7 @@ search.page = 2
 
 A lot of actions you might want to take might require an AO3 account, and if you have one, you can get access to those actions using an AO3.Session object. You start by logging in using your username and password, and then you can use that object to access restricted content.
 
-```python
+```py3
 import AO3
 
 session = AO3.Session("username", "password")
@@ -201,10 +201,10 @@ session.refresh_auth_token()
 print(session.kudos(AO3.Work(18001499, load=False))
 ```
 
-
-    Bookmarks: 67
-    True
-
+```
+Bookmarks: 67
+True
+```
 
 We successfully left kudos in a work and checked our bookmarks. The `session.refresh_auth_token()` is needed for some activities such as leaving kudos and comments. If it is expired or you forget to call this function, the error `AO3.utils.AuthError: Invalid authentication token. Try calling session.refresh_auth_token()` will be raised.
 
@@ -217,7 +217,7 @@ If you would prefer to leave a comment or kudos anonimously, you can use an `AO3
 
 To retrieve and process comment threads, you might want to look at the `Work.get_comments()` method. It returns all the comments in a specific chapter and their respective threads. You can then process them however you want. Let's take a look:
 
-```python
+```py3
 from time import time
 
 import AO3
@@ -232,20 +232,20 @@ for comment in comments:
     print(f"Comment ID: {comment.id}\nReplies: {len(comment.get_thread())}")
 ```
 
+```
+Loaded 5 comment threads in 1.8 seconds
 
-    Loaded 5 comment threads in 1.8 seconds
-
-    Comment ID: 312237184
-    Replies: 1
-    Comment ID: 312245032
-    Replies: 1
-    Comment ID: 312257098
-    Replies: 1
-    Comment ID: 312257860
-    Replies: 1
-    Comment ID: 312285673
-    Replies: 2
-
+Comment ID: 312237184
+Replies: 1
+Comment ID: 312245032
+Replies: 1
+Comment ID: 312257098
+Replies: 1
+Comment ID: 312257860
+Replies: 1
+Comment ID: 312285673
+Replies: 2
+```
 
 Loading comments takes a very long time so you should try and use it as little as possible. It also causes lots of requests to be sent to the AO3 servers, which might result in getting the error `utils.HTTPError: We are being rate-limited. Try again in a while or reduce the number of requests`. If it happens, you should try to space out your requests or reduce their number. There is also the option to enable request limiting using `AO3.utils.limit_requests()`, which make it so you can't make more than x requests in a certain time window.
 You can also reply to comments using the `Comment.reply()` function, or delete one (if it's yours) using `Comment.delete()`.

--- a/docs/use.md
+++ b/docs/use.md
@@ -8,7 +8,7 @@ One of the most basic things you might want to do with this package is loading a
 
 We start by finding the _workid_ of the work we want to load. We do that either by using `AO3.utils.workid_from_url(url)` or by just looking at the url ourselves. Let's take a look:
 
-```py3
+```python
 import AO3
 
 url = "https://archiveofourown.org/works/14392692/chapters/33236241"
@@ -27,7 +27,7 @@ Chapters: 46
 
 It's important to note that some works may not be accessible to guest users, and in this case you will get 0 chapters as an output, and the error `AO3.utils.AuthError: This work is only available to registered users of the Archive` if you try to load it. Nontheless, we can still do a lot more with this Work object: Lets try to get the first 20 words of the second chapter.
 
-```py3
+```python
 import AO3
 
 work = AO3.Work(14392692)
@@ -50,7 +50,7 @@ The objects in work.chapters are of type `AO3.Chapter`. They have a lot of the s
 
 Another thing you can do with the work object is download the entire work as a pdf or e-book. At the moment you can download works as AZW3, EPUB, HTML, MOBI, and PDF files.
 
-```py3
+```python
 import AO3
 
 work = AO3.Work(14392692)
@@ -64,7 +64,7 @@ __Advanced functionality__
 
 Usually, when you call the constructor for the `Work` class, all info about it is loaded in the `__init__()` function. However, this process takes quite some time (~1-1.5 seconds) and if you want to load a list of works from a series, for example, you might be waiting for upwards of 30 seconds. To avoid this problem, the `Work.reload()` function, called on initialization, is a "threadable" function, which means that if you call it with the argument `threaded=True`, it will return a `Thread` object and work in parallel, meaning you can load multiple works at the same time. Let's take a look at an implementation:
 
-```py3
+```python
 import AO3
 import time
 
@@ -85,7 +85,7 @@ print(f"Loaded {len(works)} works in {round(time.time()-start, 1)} seconds.")
 
 The `load=False` inside the `Work` constructor makes sure we don't load the work as soon as we create an instance of the class. In the end, we iterate over every thread and wait for the last one to finish using `.join()`. Let's compare this method with the standard way of loading AO3 works:
 
-```py3
+```python
 import AO3
 import time
 
@@ -108,7 +108,7 @@ To save even more time, if you're only interested in metadata, you can load a wo
 
 The last important information about the `Work` class is that most of its properties (like the number of bookmarks, kudos, the authors' names, etc...) are cached properties. That means that once you check them once, the value is stored and it won't ever change, even if those values change. To update these values, you will need to call `Work.reload()`. See the example below:
 
-```py3
+```python
 import AO3
 
 sess = AO3.GuestSession()
@@ -130,7 +130,7 @@ print(work.kudos)
 
 Another useful thing you might want to do is get information on who wrote which works / comments. For that, we use the `AO3.User` class.
 
-```py3
+```python
 import AO3
 
 user = AO3.User("bothersomepotato")
@@ -150,7 +150,7 @@ University student, opening documents to write essays but writing this stuff ins
 
 To search for works, you can either use the `AO3.search()` function and parse the BeautifulSoup object returned yourself, or use the `AO3.Search` class to automatically do that for you
 
-```py3
+```python
 import AO3
 search = AO3.Search(any_field="Clarke Lexa", word_count=AO3.utils.Constraint(5000, 15000))
 search.update()
@@ -184,7 +184,7 @@ for result in search.results:
 ```
 
 You can then use the workid to load one of the works you searched for. To get more then the first 20 works, change the page number using 
-```py3
+```python
 search.page = 2
 ```
 
@@ -192,7 +192,7 @@ search.page = 2
 
 A lot of actions you might want to take might require an AO3 account, and if you have one, you can get access to those actions using an AO3.Session object. You start by logging in using your username and password, and then you can use that object to access restricted content.
 
-```py3
+```python
 import AO3
 
 session = AO3.Session("username", "password")
@@ -217,7 +217,7 @@ If you would prefer to leave a comment or kudos anonimously, you can use an `AO3
 
 To retrieve and process comment threads, you might want to look at the `Work.get_comments()` method. It returns all the comments in a specific chapter and their respective threads. You can then process them however you want. Let's take a look:
 
-```py3
+```python
 from time import time
 
 import AO3


### PR DESCRIPTION
Updated to include changes to the README, also the updated code tags to use 'py3' from 'python'.
Also copied formatting from the README for the timing output in the Advanced functionality section