### PR TITLE
Utility to get a work title using the work ID

### DIFF
--- a/AO3/utils.py
+++ b/AO3/utils.py
@@ -204,6 +204,33 @@ def workid_from_url(url):
             return int(workid)
     return
 
+def worktitle_from_workid(workid):
+    """Get the work title from an archiveofourown.org work ID
+    Args:
+        workid (int): Work ID
+    Returns:
+        string: Work Title
+    """
+    # Convert ID (int) to string and concatenate with website URL
+    workid = str(workid)
+    url = str("https://archiveofourown.org/works/" + workid)
+
+    # Get page content and parse with BeatifulSoup
+    if requests.get(url).ok == True:
+        soupget = requests.get(url, timeout=5).content
+        soup = BeautifulSoup(soupget, 'html.parser')
+    else:
+        raise HTTPError("Request failure. Try again in a while or reduce the number of requests")
+ 
+    # Get work title HTML class
+    worktitle = soup.find('h2', {'class': 'title heading'})
+
+    # Convert class content to string and strip the whitespace
+    worktitle = worktitle.text
+    worktitle = worktitle.strip()
+
+    return worktitle
+
 def comment(commentable, comment_text, sess, fullwork=False, commentid=None, email="", name=""):
     """Leaves a comment on a specific work
 


### PR DESCRIPTION
Uses already included 'requests' import and the HTTPError class for error handling. 
I also included a timeout in the GET request and a HTTP status code check. 

Lines 229 and 230 were cleaner when written as individual steps instead of a one liner.

Tested on a list of 80 work ID's (As much I could run until I got timed out)
Also handles titles with special characters in the line, example: 14.06 It’s Not F*@!~#g Archie!