### PR TITLE
Fixed bug with loading a work

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -78,7 +78,7 @@ class Work:
                     delattr(self, attr)
         
         self._soup = self.request(f"https://archiveofourown.org/works/{self.id}?view_adult=true&view_full_work=true")
-        if "Error 404" in self._soup.text:
+        if "Error 404" in self._soup.find("h2", {"class", "heading"}).text:
             raise utils.InvalidIdError("Cannot find work")
         if load_chapters:
             self.load_chapters()


### PR DESCRIPTION
Fixed a bug where if a work has 'Error 404' in its text, an InvalidIDError will be raised even if the work is valid