### PR TITLE
`get_marked_for_later` inits `Work`s with session

### DIFF
--- a/AO3/session.py
+++ b/AO3/session.py
@@ -557,7 +557,7 @@ class Session(GuestSession):
                     for work in worksRaw:
                         try:
                             workId = int(work.h4.a.get("href").split("/")[2])
-                            works.append(Work(workId, load=False))
+                            works.append(Work(workId, session=self, load=False))
                         except AttributeError:
                             pass
                     grabbed = True


### PR DESCRIPTION
This PR makes a small change: it amends `Session.get_marked_for_later` to pass `session=self` when initializing each work. This should allow the resulting works to be loaded and interacted with in cases where a session is required.

I'm new to the project, so apologies if I haven't gone about this the right way!

Closes #66.