### PR TITLE
Basic Collection Interactions

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -472,6 +472,27 @@ class Work:
             raise utils.BookmarkError("You don't have a bookmark here")
         
         utils.delete_bookmark(self._bookmarkid, self._session, self.authenticity_token)
+    
+    @threadable.threadable
+    def collect(self, collections):
+        """Invites/collects this work to a collection or collections
+        This function is threadable
+
+        Args:
+            collections (list): What collections to add this work to. Defaults to None.
+
+        Raises:
+            utils.UnloadedError: Work isn't loaded
+            utils.AuthError: Invalid session
+        """
+        
+        if not self.loaded:
+            raise utils.UnloadedError("Work isn't loaded. Have you tried calling Work.reload()?")
+        
+        if self._session is None:
+            raise utils.AuthError("Invalid session")
+          
+        utils.collect(self, self._session, collections)
         
     @cached_property
     def _bookmarkid(self):


### PR DESCRIPTION
Adds:
ability for the API to add/invite works to collections
ability for the API to list the collections a work belongs to

Required things to get this working:

> import AO3
> session = AO3.Session("Username/email", "Password")
> url = "http://archiveofourown.org/works/6037795"

> workid = AO3.utils.workid_from_url(url)
> work = AO3.Work(workid, session)

> user_collections = ["Collection1ID","Collection2ID"]
> work.collect(user_collections)

Additional testing to be done, but I thought I'd share