### PR TITLE
(fix) make changes to _load_bookmarks after AO3-6325

### DIFF
--- a/AO3/session.py
+++ b/AO3/session.py
@@ -469,7 +469,7 @@ class Session(GuestSession):
         url = self._bookmarks_url.format(self.username, page)
         soup = self.request(url)
         bookmarks = soup.find("ol", {"class": "bookmark index group"})
-        for bookm in bookmarks.find_all("li", {"class": "bookmark blurb group"}):
+        for bookm in bookmarks.find_all("li", {"class": re.compile("^bookmark blurb group")}):
             authors = []
             workid = -1
             if bookm.h4 is not None:


### PR DESCRIPTION
Fixed an issue with `get_bookmarks()` where the return object would always be `[]`. 
[AO3-6325](https://github.com/otwcode/otwarchive/commit/987e9e94440304c59d40e2d4e2fade5386eb11ba) made a change to the `li` class so it is no longer called `bookmark blurb group`, but is now a dynamic value.