### PR TITLE
Add recommended status to returned bookmarks

### DIFF
--- a/AO3/session.py
+++ b/AO3/session.py
@@ -471,6 +471,7 @@ class Session(GuestSession):
         bookmarks = soup.find("ol", {"class": "bookmark index group"})
         for bookm in bookmarks.find_all("li", {"class": ["bookmark", "index", "group"]}):
             authors = []
+            recommended = False
             workid = -1
             if bookm.h4 is not None:
                 for a in bookm.h4.find_all("a"):
@@ -480,11 +481,19 @@ class Session(GuestSession):
                     elif a.attrs["href"].startswith("/works"):
                         workname = str(a.string)
                         workid = utils.workid_from_url(a["href"])
+
+                # Get whether the bookmark is recommended
+                for span in bookm.p.find_all("span"):
+                    if "title" in span.attrs.keys():
+                        if span["title"] == "Rec":
+                            recommended = True
+
             
                 if workid != -1:
                     new = Work(workid, load=False)
                     setattr(new, "title", workname)
                     setattr(new, "authors", authors)
+                    setattr(new, "recommended", recommended)
                     if new not in self._bookmarks:
                         self._bookmarks.append(new)
             


### PR DESCRIPTION
Returns whether the user has "recommended" the bookmark. 

I wound up subclassing `Session` so I could override `_load_bookmarks()` and get this info myself, so I though I would submit a PR in case this was something you wanted to add. I'm working on a better way to manage my TBRs and fics I've read, so getting some facsimile of the "read" status was helpful for me. 

Example of the UI for a "recommended" bookmark -- note the little heart: 
![Screen Shot 2022-10-24 at 12 19 53 PM](https://user-images.githubusercontent.com/2286304/197608446-7a320f0c-e46f-4919-986b-70d120e1b472.png)

And the HTML: 
```html
    <p class="status" title="702 Bookmarks">
       <a class="help symbol question modal" title="Bookmark symbols key" aria-controls="#modal" href="/help/bookmark-symbols-key.html">
        <!-- This is the line we are looking at -->
        <span class="rec" title="Rec"><span class="text">Rec</span></span>
      </a>
      <span class="count"><a href="/works/33285814/bookmarks">*</a></span>
    </p>
```

Here is the UI for a bookmark that doesn't have "recommended" selected: 
![Screen Shot 2022-10-24 at 12 20 00 PM](https://user-images.githubusercontent.com/2286304/197608655-82ca0ff8-ef7f-4540-9b7d-147c5e7c2823.png)

And the HTML for that as well: 
```html
    <p class="status" title="3490 Bookmarks">
       <a class="help symbol question modal" title="Bookmark symbols key" aria-controls="#modal" href="/help/bookmark-symbols-key.html">
        <!-- This is the line we are looking at -->
        <span class="public" title="Public Bookmark"><span class="text">Public Bookmark</span></span>
      </a>
      <span class="count"><a href="/works/13625910/bookmarks">*</a></span>
    </p>
```
