### PR TITLE
Warning for Mistery Works

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -72,14 +72,20 @@ class Work:
             load_chapters (bool, optional): If false, chapter text won't be parsed, and Work.load_chapters() will have to be called. Defaults to True.
         """
         
+        self._soup = self.request(f"https://archiveofourown.org/works/{self.id}?view_adult=true&view_full_work=true")
+
+        try: 
+            if "Error 404" in self._soup.find("h2", {"class", "heading"}).text:
+                raise utils.InvalidIdError("Cannot find work")
+        except AttributeError:
+            warnings.warn("This work failed to load. This is probably because the work is restricted or a Mistery Work")
+            return 
+
         for attr in self.__class__.__dict__:
             if isinstance(getattr(self.__class__, attr), cached_property):
                 if attr in self.__dict__:
                     delattr(self, attr)
         
-        self._soup = self.request(f"https://archiveofourown.org/works/{self.id}?view_adult=true&view_full_work=true")
-        if "Error 404" in self._soup.find("h2", {"class", "heading"}).text:
-            raise utils.InvalidIdError("Cannot find work")
         if load_chapters:
             self.load_chapters()
         


### PR DESCRIPTION
When the work is being loaded it warns the user if it's a Mistery Work and stops loading the rest, so that Mistery Works no longer cause an error.
It would fix the issue #81 