### PR TITLE
get_bookmarks from User

### DIFF
--- a/AO3/common.py
+++ b/AO3/common.py
@@ -31,7 +31,7 @@ def get_work_from_banner(work):
             if 'rel' in a.attrs.keys():
                 if "author" in a['rel']:
                     authors.append(User(a.string, load=False))
-            elif a.attrs["href"].startswith("/works"):
+            elif "works/" in a.attrs["href"]:
                 workname = a.string
                 workid = utils.workid_from_url(a['href'])
     except AttributeError:

--- a/AO3/common.py
+++ b/AO3/common.py
@@ -7,6 +7,17 @@ def __setifnotnone(obj, attr, value):
     if value is not None:
         setattr(obj, attr, value)
 
+def get_work_or_series_from_banner(banner):
+    from .series import Series
+
+    a = banner.h4.find_all("a")[0]
+
+    if "/series" in a['href']:
+        seriesid = a['href'].split("/")[-1]
+        return Series(seriesid)
+
+    return get_work_from_banner(banner)
+
 def get_work_from_banner(work):
     #* These imports need to be here to prevent circular imports
     #* (series.py would requite common.py and vice-versa)

--- a/AO3/users.py
+++ b/AO3/users.py
@@ -264,7 +264,7 @@ class User:
         ol = self._soup_works.find("ol", {"class": "work index group"})
 
         for work in ol.find_all("li", {"role": "article"}):
-            if work.h4 is None:
+            if work.h4 is None or work.h4.a is None:
                 continue
             self._works.append(get_work_from_banner(work))
 
@@ -333,9 +333,9 @@ class User:
 
         for work in ol.find_all("li", {"role": "article"}):
             authors = []
-            if work.h4 is None:
+            if work.h4 is None or work.h4.a is None:
                 continue
-            self._bookmarks.append(get_work_from_banner(work))
+            self._bookmarks.append(get_work_or_series_from_banner(work))
     
     @cached_property
     def bio(self):


### PR DESCRIPTION
This should fix #86 

The problem was that when a series banner was passed to get_work_from_banner instead of a work, this condition is never true:
```elif a.attrs["href"].startswith("/works"):```
 
This means that the workid is never initialized and there's an UnboundLocalError when we try to create a Work object.
We can fix it by checking if the banner is the banner of a series or a work, so the get_work_from_banner is only called when we have a work and it doesn't raise that error.

This doesn't fix the problem completely, because mistery works and external works still raise an error. 
The external works problem can be fixed by changing the sintaxis of the condition that sets the workid, so that it is true for any string with "works/" in it, instead of strings that start with "/works".
The mistery works problem can be fixed by checking the h4 tag before calling get_work_from_banner. This way, it skips the mistery works.
