### PR TITLE
Username capitalization

### DIFF
--- a/AO3/session.py
+++ b/AO3/session.py
@@ -508,11 +508,9 @@ class Session(GuestSession):
 
         url = self._bookmarks_url.format(self.username, 1)
         soup = self.request(url)
-        div = soup.find("div", {"id": "inner"})
-        span = div.find("span", {"class": "current"}).getText().replace("(", "").replace(")", "")
-        n = span.split(" ")[1]
-        
-        return int(self.str_format(n))
+        div = soup.find("div", {"class": "bookmarks-index dashboard filtered region"})
+        h2 = div.h2.text.split()
+        return int(h2[4].replace(',', ''))
     
     def get_statistics(self, year=None):
         year = "All+Years" if year is None else str(year)

--- a/AO3/users.py
+++ b/AO3/users.py
@@ -208,10 +208,9 @@ class User:
             int: Number of works
         """
 
-        div = self._soup_works.find("div", {"id": "inner"})
-        span = div.find("span", {"class": "current"}).getText().replace("(", "").replace(")", "")
-        n = span.split(" ")[1]
-        return int(self.str_format(n))   
+        div = self._soup_works.find("div", {"class": "works-index dashboard filtered region"})
+        h2 = div.h2.text.split()
+        return int(h2[4].replace(',', '')) 
 
     @cached_property
     def _works_pages(self):
@@ -276,10 +275,9 @@ class User:
             int: Number of bookmarks 
         """
 
-        div = self._soup_bookmarks.find("div", {"id": "inner"})
-        span = div.find("span", {"class": "current"}).getText().replace("(", "").replace(")", "")
-        n = span.split(" ")[1]
-        return int(self.str_format(n))   
+        div = self._soup_bookmarks.find("div", {"class": "bookmarks-index dashboard filtered region"})
+        h2 = div.h2.text.split()
+        return int(h2[4].replace(',', ''))  
 
     @cached_property
     def _bookmarks_pages(self):


### PR DESCRIPTION
fix #79 

The problem was that when the capitalization wasn't correct the html tags which had the information about the number of bookmarks changed. When the username was written correctly the tag would be ```span``` and when in wasn't it would be ```a```. 
So instead of obtaining the information from the navigation panel I changed the code and now it takes that information from the heading of the page:
```1 - 20 of 587 Bookmarks by ...```

I also changed the code for user.bookmarks and user.works, because they caused the same error if the capitalization was wrong
