### PR TITLE
works.py - Rare words.string NoneType

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -653,7 +653,7 @@ class Work:
         """
 
         words = self._soup.find("dd", {"class": "words"})
-        if words is not None:
+        if words is not None and words.string is not None:
             return int(self.str_format(words.string))
         return 0
 


### PR DESCRIPTION
In rare cases work can contain the field "words" but won't contain anything in itself (words.string is None) raising a runtime error.