### PR TITLE
Added ability to retrieve a work's workskin

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -559,6 +559,12 @@ class Work:
         return author_list
 
     @cached_property
+    def workskin(self):
+        """Returns the CSS code for this work's workskin"""
+        skin = self._soup.find("style", {"type": "text/css"})
+        return skin
+
+    @cached_property
     def nchapters(self):
         """Returns the number of chapters of this work
 

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -560,10 +560,14 @@ class Work:
 
     @cached_property
     def workskin(self):
-        """Returns the CSS code for this work's workskin"""
+        """Returns the CSS code for this work's workskin
+
+        Returns:
+            str: CSS code for the workskin. Empty string if no workskin.
+        """
         skin = self._soup.find("style", {"type": "text/css"})
         if skin is not None:
-            return skin.decode_contents()
+            return str(skin.decode_contents())
         return ""
 
     @cached_property

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -562,7 +562,7 @@ class Work:
     def workskin(self):
         """Returns the CSS code for this work's workskin"""
         skin = self._soup.find("style", {"type": "text/css"})
-        return skin
+        return skin.decode_contents()
 
     @cached_property
     def nchapters(self):

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -562,7 +562,9 @@ class Work:
     def workskin(self):
         """Returns the CSS code for this work's workskin"""
         skin = self._soup.find("style", {"type": "text/css"})
-        return skin.decode_contents()
+        if skin is not None:
+            return skin.decode_contents()
+        return ""
 
     @cached_property
     def nchapters(self):

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -565,9 +565,11 @@ class Work:
         Returns:
             str: CSS code for the workskin. Empty string if no workskin.
         """
-        skin = self._soup.find("style", {"type": "text/css"})
-        if skin is not None:
-            return str(skin.decode_contents())
+        allStyles = self._soup.find_all("style", {"type": "text/css"})
+        if len(allStyles) != 0:
+            text = str(allStyles[-1].decode_contents())
+            if text.find("#workskin") != -1:
+                return text
         return ""
 
     @cached_property


### PR DESCRIPTION
Added a workskin() function in works.py, which returns the contents of the first <style type:"text/css"> tag it can find. In every case I've checked, that tag (if it exists) will contain the CSS code for the 'workskin', [custom theming that authors can put on their works.](https://archiveofourown.org/admin_posts/1370) Returns an empty string if there is no workskin.