### PR TITLE
Added new Exception raised when trying to load restricted work without session

### DIFF
--- a/AO3/series.py
+++ b/AO3/series.py
@@ -368,6 +368,8 @@ class Series:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
         if req.status_code == 429:
             raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        if req.history and req.url.find("/users/login?restricted=true") != -1:
+            raise utils.PrivateWorkError(f"Error 302: Redirected to [{req.url}]")
         return req
 
     def request(self, url):

--- a/AO3/utils.py
+++ b/AO3/utils.py
@@ -68,6 +68,11 @@ class CollectError(Exception):
         super().__init__(message)
         self.errors = errors
 
+class PrivateWorkError(Exception):
+    def __init__(self, message, errors=[]):
+        super().__init__(message)
+        self.errors = errors
+
 class Query:
     def __init__(self):
         self.fields = []

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -923,6 +923,8 @@ class Work:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
         if req.status_code == 429:
             raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        if req.history and req.url.find("/users/login?restricted=true") != -1:
+            raise utils.PrivateWorkError(f"Error 302: Redirected to [{req.url}]")
         return req
 
     def request(self, url):


### PR DESCRIPTION
This PR adds a new Exception in Utils, the PrivateWorkError, which is called when works.get() detects it has been redirected to the login page, instead of the previous behavior where an AttributeError would be raised when the rest of works.py attempted to parse the login page as though it were a works page.

Works in the single test case I've tried so far, will mark as ready to merge once tested on a larger dataset.