### PR TITLE
Added handling for cloudflare ssl errors (http error 525)

### DIFF
--- a/AO3/chapters.py
+++ b/AO3/chapters.py
@@ -316,6 +316,11 @@ class Chapter:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req

--- a/AO3/comments.py
+++ b/AO3/comments.py
@@ -249,8 +249,13 @@ class Comment:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req
     
 def threadIterator(comment):

--- a/AO3/series.py
+++ b/AO3/series.py
@@ -366,8 +366,13 @@ class Series:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req
 
     def request(self, url):

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -106,8 +106,13 @@ class GuestSession:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req
 
     def request(self, url):

--- a/AO3/users.py
+++ b/AO3/users.py
@@ -366,8 +366,13 @@ class User:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req
 
     def request(self, url):

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -921,8 +921,13 @@ class Work:
             req = requester.request("get", *args, **kwargs)
         else:
             req = requester.request("get", *args, **kwargs, session=self._session.session)
-        if req.status_code == 429:
-            raise utils.HTTPError("We are being rate-limited. Try again in a while or reduce the number of requests")
+        match req.status_code:
+            case 429:
+                raise utils.HTTPError(
+                    "Error 429: We are being rate-limited. Try again in a while or reduce the number of requests"
+                )
+            case 525:
+                raise utils.HTTPError("Error 525: SSL Error")
         return req
 
     def request(self, url):


### PR DESCRIPTION
works.get() will now detect a status code of 525 (signifying that there was an SSL error between Cloudflare's reverse-proxy and AO3's servers) and raise an HTTPError, instead of the previous behavior where an AttributeError would be raised when the rest of works.py tried to parse the cloudflare error page as though it were a normal work page.
Also added the HTTP error number to the text of both this exception and the existing rate-limiting exception, so that the  type of error can be easily found using ordinary string parsing.