### PR TITLE
Updated target of find() in User._works_pages

### DIFF
--- a/AO3/users.py
+++ b/AO3/users.py
@@ -214,7 +214,7 @@ class User:
 
     @cached_property
     def _works_pages(self):
-        pages = self._soup_works.find("ol", {"title": "pagination"})
+        pages = self._soup_works.find("ol", {"aria-label": "Pagination"})
         if pages is None:
             return 1
         n = 1


### PR DESCRIPTION
Changed the target for the `find()` in `users._works_pages`, resulting in the 'pages' local variable being successfully set, resulting in `_works_pages` not falling back to the default value of 1, resulting in `User.get_works()` returning more than the 20 most recently updated works. Resolves Issue #113 