### PR TITLE
feat: Search for people

### DIFF
--- a/AO3/__init__.py
+++ b/AO3/__init__.py
@@ -1,6 +1,7 @@
 from . import extra, utils
 from .chapters import Chapter
 from .comments import Comment
+from .peoplesearch import PeopleSearch
 from .search import Search
 from .series import Series
 from .session import GuestSession, Session

--- a/AO3/peoplesearch.py
+++ b/AO3/peoplesearch.py
@@ -49,7 +49,8 @@ class PeopleSearch:
             users.append(User(username, session=self.session, load=False))
 
         self.results = users
-        self.total_results = int(result_count.string.split()[0])
+        total_str = result_count.string.split()[0].replace(",", "")
+        self.total_results = int(total_str)
         self.pages = ceil(self.total_results / 20)
 
 

--- a/AO3/peoplesearch.py
+++ b/AO3/peoplesearch.py
@@ -1,0 +1,96 @@
+import re
+from math import ceil
+
+from bs4 import BeautifulSoup
+
+from . import threadable, utils
+from .requester import requester
+from .users import User
+
+
+class PeopleSearch:
+    def __init__(self, all_fields="", names="", fandoms="", page=1, session=None):
+
+        self.all_fields = all_fields
+        self.names = names
+        self.fandoms = fandoms
+        self.page = page
+
+        self.session = session
+
+        self.results = None
+        self.pages = 0
+        self.total_results = 0
+
+    @threadable.threadable
+    def update(self):
+        """Sends a request to the AO3 website with the defined search parameters, and updates all info.
+        This function is threadable.
+        """
+        soup = search(
+            self.all_fields, self.names, self.fandoms, self.page, self.session
+        )
+
+        results = soup.find("ol", {"class": ("pseud", "index", "group")})
+        result_count = soup.find("p", string=re.compile(r"\d+ Found"))
+
+        if results is None or result_count is None:
+            self.results = []
+            self.total_results = 0
+            self.pages = 0
+            return
+
+        users = []
+        for result in results.find_all("li", {"role": "article"}):
+            link = result.find(href=re.compile(r"^/users/"))
+            if link is None:
+                continue
+            username = link.attrs["href"].split("/")[2]
+            users.append(User(username, session=self.session, load=False))
+
+        self.results = users
+        self.total_results = int(result_count.string.split()[0])
+        self.pages = ceil(self.total_results / 20)
+
+
+def search(
+    all_fields="",
+    names="",
+    fandoms="",
+    page=1,
+    session=None,
+):
+    """Returns the results page for the people search as a Soup object
+    Args:
+        all_fields (str, optional): Generic search. Defaults to "".
+        names (str, optional): Names of users. Defaults to "".
+        fandoms (str, optional): Fandoms in which the users have works. Defaults to "".
+        page (int, optional): Page number. Defaults to 1.
+        session (AO3.Session, optional): Session object. Defaults to None.
+
+    Returns:
+        bs4.BeautifulSoup: Search result's soup
+    """
+
+    query = utils.Query()
+    if page != 1:
+        query.add_field(f"page={page}")
+    if all_fields != "":
+        query.add_field(f"people_search[query]={all_fields}")
+    if names != "":
+        query.add_field(f"people_search[name]={names}")
+    if fandoms != "":
+        query.add_field(f"people_search[fandom]={fandoms}")
+
+    url = f"https://archiveofourown.org/people/search?{query.string}"
+
+    if session is None:
+        req = requester.request("get", url)
+    else:
+        req = session.get(url)
+    if req.status_code == 429:
+        raise utils.HTTPError(
+            "We are being rate-limited. Try again in a while or reduce the number of requests"
+        )
+    soup = BeautifulSoup(req.content, features="lxml")
+    return soup

--- a/AO3/peoplesearch.py
+++ b/AO3/peoplesearch.py
@@ -9,7 +9,13 @@ from .users import User
 
 
 class PeopleSearch:
-    def __init__(self, all_fields="", names="", fandoms="", page=1, session=None):
+    def __init__(
+        self,
+        all_fields="",
+        names="",
+        fandoms="",
+        page=1,
+        session=None):
 
         self.all_fields = all_fields
         self.names = names
@@ -27,13 +33,13 @@ class PeopleSearch:
         """Sends a request to the AO3 website with the defined search parameters, and updates all info.
         This function is threadable.
         """
+
         soup = search(
             self.all_fields, self.names, self.fandoms, self.page, self.session
         )
 
         results = soup.find("ol", {"class": ("pseud", "index", "group")})
         result_count = soup.find("p", string=re.compile(r"\d+ Found"))
-
         if results is None or result_count is None:
             self.results = []
             self.total_results = 0
@@ -59,8 +65,7 @@ def search(
     names="",
     fandoms="",
     page=1,
-    session=None,
-):
+    session=None):
     """Returns the results page for the people search as a Soup object
     Args:
         all_fields (str, optional): Generic search. Defaults to "".

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ for result in people.results:
 <User [crumpsy]>
 ```
 
-You can then use the User objects to load one of the users. To get more then the first 20 user, change the page number using 
+You can then use the User objects to load one of the users. To get more then the first 20 users, change the page number using 
 ```py3
 people.page = 2
 people.update()

--- a/README.md
+++ b/README.md
@@ -202,9 +202,53 @@ for result in search.results:
 <Work [My only wish]>
 ```
 
-You can then use the workid to load one of the works you searched for. To get more then the first 20 works, change the page number using 
+You can then use the Work objects to load one of the works you searched for. To get more then the first 20 works, change the page number using 
 ```py3
 search.page = 2
+search.update()
+```
+
+## People Search
+
+To search for people, use the `AO3.PeopleSearch` class.
+
+```py3
+import AO3
+people = AO3.PeopleSearch(fandoms="Supernatural (TV 2005)")
+people.update()
+print(people.total_results)
+for result in people.results:
+  print(result)
+```
+
+```
+46509
+<User [thisismypseudonym]>
+<User [honeycas]>
+<User [Lizaredlion]>
+<User [skullsandravens]>
+<User [blurry_dreams]>
+<User [heythere_itsdeanwinchester]>
+<User [LeWriter241]>
+<User [MissSultanofswing]>
+<User [Rayra]>
+<User [Alaida]>
+<User [Defiler_Wyrm]>
+<User [Mr_Mackwo]>
+<User [orphan_account]>
+<User [MadnessReg]>
+<User [mooseysammy]>
+<User [IAmNoMant]>
+<User [Bookluvr3]>
+<User [destielxxdreaming]>
+<User [orphan_account]>
+<User [crumpsy]>
+```
+
+You can then use the User objects to load one of the users. To get more then the first 20 user, change the page number using 
+```py3
+people.page = 2
+people.update()
 ```
 
 ## Session

--- a/docs/use.md
+++ b/docs/use.md
@@ -183,9 +183,53 @@ for result in search.results:
 <Work [My only wish]>
 ```
 
-You can then use the workid to load one of the works you searched for. To get more then the first 20 works, change the page number using 
-```python
+You can then use the Work objects to load one of the works you searched for. To get more then the first 20 works, change the page number using 
+```py3
 search.page = 2
+search.update()
+```
+
+## People Search
+
+To search for people, use the `AO3.PeopleSearch` class.
+
+```py3
+import AO3
+people = AO3.PeopleSearch(fandoms="Supernatural (TV 2005)")
+people.update()
+print(people.total_results)
+for result in people.results:
+  print(result)
+```
+
+```
+46509
+<User [thisismypseudonym]>
+<User [honeycas]>
+<User [Lizaredlion]>
+<User [skullsandravens]>
+<User [blurry_dreams]>
+<User [heythere_itsdeanwinchester]>
+<User [LeWriter241]>
+<User [MissSultanofswing]>
+<User [Rayra]>
+<User [Alaida]>
+<User [Defiler_Wyrm]>
+<User [Mr_Mackwo]>
+<User [orphan_account]>
+<User [MadnessReg]>
+<User [mooseysammy]>
+<User [IAmNoMant]>
+<User [Bookluvr3]>
+<User [destielxxdreaming]>
+<User [orphan_account]>
+<User [crumpsy]>
+```
+
+You can then use the User objects to load one of the users. To get more then the first 20 user, change the page number using 
+```py3
+people.page = 2
+people.update()
 ```
 
 ## Session

--- a/docs/use.md
+++ b/docs/use.md
@@ -226,7 +226,7 @@ for result in people.results:
 <User [crumpsy]>
 ```
 
-You can then use the User objects to load one of the users. To get more then the first 20 user, change the page number using 
+You can then use the User objects to load one of the users. To get more then the first 20 users, change the page number using 
 ```py3
 people.page = 2
 people.update()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao3-api"
-version = "2.3.1"
+version = "2.4.0"
 authors = [
   { name="Wendy" },
 ]


### PR DESCRIPTION
Add support for /people/search. The form is much simpler than
/works/search, having only three fields. And a `User` object is much
simpler, needing only the username.

In theory, more of the user data could be parsed from the search
results, but calling user.reload() seems like a better choice.

I tried to keep the API consistent with AO3.Search, but chose
'all_fields' instead of 'any_field' in order to be consistent with the
AO3 people search form.

Update the version to 2.4.0 to indicate new capability added.