### PR TITLE
Fixing the pagination issue #123

### DIFF
--- a/AO3/users.py
+++ b/AO3/users.py
@@ -214,7 +214,7 @@ class User:
 
     @cached_property
     def _works_pages(self):
-        pages = self._soup_works.find("ol", {"title": "pagination"})
+        pages = self._soup_works.find("ol", {"class": "pagination"})
         if pages is None:
             return 1
         n = 1
@@ -281,7 +281,7 @@ class User:
 
     @cached_property
     def _bookmarks_pages(self):
-        pages = self._soup_bookmarks.find("ol", {"title": "pagination"})
+        pages = self._soup_bookmarks.find("ol", {"class": "pagination"})
         if pages is None:
             return 1
         n = 1


### PR DESCRIPTION
Made changes to `AO3.User._works_pages` and `AO3.User._bookmarks_pages`.
Instead of looking for an ordered list with the title "pagination", they look for one with the class "pagination".