### PR TITLE
edited work validity checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -169,7 +169,6 @@ class Session(GuestSession):
                    'authenticity_token': self.authenticity_token}
         post = self.post("https://archiveofourown.org/users/login", params=payload, allow_redirects=True)
         current_url = post.url
-        print("reached page: " + current_url)
         if current_url.endswith("archiveofourown.org/auth_error"):
             raise utils.LoginError("Could not login. Reached auth error page. Be certain you used the right username and password")
 

--- a/AO3/session.py
+++ b/AO3/session.py
@@ -167,9 +167,11 @@ class Session(GuestSession):
         payload = {'user[login]': username,
                    'user[password]': password,
                    'authenticity_token': self.authenticity_token}
-        post = self.post("https://archiveofourown.org/users/login", params=payload, allow_redirects=False)
-        if not post.status_code == 302:
-            raise utils.LoginError("Invalid username or password")
+        post = self.post("https://archiveofourown.org/users/login", params=payload, allow_redirects=True)
+        current_url = post.url
+        print("reached page: " + current_url)
+        if current_url.endswith("archiveofourown.org/auth_error"):
+            raise utils.LoginError("Could not login. Reached auth error page. Be certain you used the right username and password")
 
         self._subscriptions_url = "https://archiveofourown.org/users/{0}/subscriptions?page={1:d}"
         self._bookmarks_url = "https://archiveofourown.org/users/{0}/bookmarks?page={1:d}"

--- a/AO3/tests/sanity_tests.py
+++ b/AO3/tests/sanity_tests.py
@@ -1,0 +1,46 @@
+from AO3 import Work, utils, Session
+import AO3
+from AO3.utils import LoginError
+
+
+def find_public_works():
+    url = "https://archiveofourown.org/works/79206236/chapters/207814801"
+    workid = utils.workid_from_url(url)
+    print(f"Work ID: {workid}")
+    work = Work(workid)
+    print(f"Chapters: {work.nchapters}")
+
+    assert workid == 79206236
+    assert work.nchapters == 11
+
+
+def load_logged_in_work():
+    try:
+        url = "https://archiveofourown.org/works/14392692/chapters/33236241"
+        workid = utils.workid_from_url(url)
+        work = Work(workid)
+    except Exception as e:
+        assert e is utils.AuthError
+
+def attempt_login():
+    session = Session(input("Username? "), input("password? "))
+    print(f"Bookmarks: {session.bookmarks}")
+    url = "https://archiveofourown.org/works/14392692/chapters/33236241"
+    workid = utils.workid_from_url(url)
+    work = Work(workid, session=session)
+
+def attempt_incorrect_login():
+    try:
+        session = Session("username", "password")
+        print(f"Bookmarks: {session.bookmarks}")
+        url = "https://archiveofourown.org/works/14392692/chapters/33236241"
+        workid = utils.workid_from_url(url)
+        work = Work(workid, session=session)
+    except Exception as e:
+        assert isinstance(e, AO3.utils.LoginError)
+
+
+#find_public_works()
+#load_logged_in_work()
+attempt_login()
+# attempt_incorrect_login()

--- a/AO3/tests/sanity_tests.py
+++ b/AO3/tests/sanity_tests.py
@@ -1,6 +1,5 @@
 from AO3 import Work, utils, Session
 import AO3
-from AO3.utils import LoginError
 
 
 def find_public_works():
@@ -14,33 +13,51 @@ def find_public_works():
     assert work.nchapters == 11
 
 
-def load_logged_in_work():
+def load_locked_work():
     try:
         url = "https://archiveofourown.org/works/14392692/chapters/33236241"
         workid = utils.workid_from_url(url)
-        work = Work(workid)
+        Work(workid)
     except Exception as e:
-        assert e is utils.AuthError
+        assert isinstance(e, AO3.utils.AuthError)
+        print("Loading a locked work without logging in raises AuthError")
+
+def load_hidden_work():
+    try:
+        url = "https://archiveofourown.org/works/52985041/chapters/134037295"
+        workid = utils.workid_from_url(url)
+        Work(workid)
+    except Exception as e:
+        assert isinstance(e, AO3.utils.HiddenWorkError)
+        print("Loading a locked work without logging in raises HiddenWorkError")
+
+def load_nonexistent_work():
+    try:
+        url = "https://archiveofourown.org/works/99999999999999999999"
+        workid = utils.workid_from_url(url)
+        Work(workid)
+    except Exception as e:
+        assert isinstance(e, AO3.utils.InvalidIdError)
+        print("Loading a non-existent work raises InvalidIdError")
+
+def attempt_incorrect_login():
+    try:
+        Session("username", "password")
+    except Exception as e:
+        assert isinstance(e, AO3.utils.LoginError)
+        print("Logging in with invalid credentials raises LoginError")
 
 def attempt_login():
     session = Session(input("Username? "), input("password? "))
     # print(f"Bookmarks: {session.bookmarks}")
     url = "https://archiveofourown.org/works/14392692/chapters/33236241"
     workid = utils.workid_from_url(url)
-    work = Work(workid, session=session)
-
-def attempt_incorrect_login():
-    try:
-        session = Session("username", "password")
-        print(f"Bookmarks: {session.bookmarks}")
-        url = "https://archiveofourown.org/works/14392692/chapters/33236241"
-        workid = utils.workid_from_url(url)
-        work = Work(workid, session=session)
-    except Exception as e:
-        assert isinstance(e, AO3.utils.LoginError)
+    Work(workid, session=session)
 
 
-#find_public_works()
-#load_logged_in_work()
-attempt_login()
-# attempt_incorrect_login()
+# find_public_works()
+load_locked_work()
+load_nonexistent_work()
+load_hidden_work()
+attempt_incorrect_login()
+# attempt_login()

--- a/AO3/tests/sanity_tests.py
+++ b/AO3/tests/sanity_tests.py
@@ -24,7 +24,7 @@ def load_logged_in_work():
 
 def attempt_login():
     session = Session(input("Username? "), input("password? "))
-    print(f"Bookmarks: {session.bookmarks}")
+    # print(f"Bookmarks: {session.bookmarks}")
     url = "https://archiveofourown.org/works/14392692/chapters/33236241"
     workid = utils.workid_from_url(url)
     work = Work(workid, session=session)

--- a/AO3/utils.py
+++ b/AO3/utils.py
@@ -32,6 +32,11 @@ class InvalidIdError(Exception):
     def __init__(self, message, errors=[]):
         super().__init__(message)
         self.errors = errors
+
+class HiddenWorkError(Exception):
+    def __init__(self, message, errors=[]):
+        super().__init__(message)
+        self.errors = errors
         
 class DownloadError(Exception):
     def __init__(self, message, errors=[]):

--- a/AO3/works.py
+++ b/AO3/works.py
@@ -76,10 +76,30 @@ class Work:
             if isinstance(getattr(self.__class__, attr), cached_property):
                 if attr in self.__dict__:
                     delattr(self, attr)
-        
-        self._soup = self.request(f"https://archiveofourown.org/works/{self.id}?view_adult=true&view_full_work=true")
-        if "Error 404" in self._soup.find("h2", {"class", "heading"}).text:
+
+        req = self.request_raw(f"https://archiveofourown.org/works/{self.id}?view_adult=true&view_full_work=true")
+        self._soup = self.create_work(req)
+
+        # check that work is in the format we expect
+        if "archiveofourown.org/users/login" in req.url:
+            raise utils.AuthError("This work is only available to registered users of the Archive")
+
+        missing_work_notif = self._soup.find("h2", {"class", "heading"})
+        if missing_work_notif is not None and "Error 404" in missing_work_notif.text:
             raise utils.InvalidIdError("Cannot find work")
+
+        hidden_work_notif = self._soup.find("p", {"class", "notice"})
+        if hidden_work_notif is None:
+            hidden_work_notif = self._soup.find("li", {"class", "mystery"})
+        if (hidden_work_notif is not None and
+                "This work is part of an ongoing challenge and will be revealed soon!" in hidden_work_notif.text
+        ):
+            raise utils.HiddenWorkError("This work is hidden and cannot be viewed except by the author.")
+
+        work_container = self._soup.find("div", {"id", "workskin"})
+        if work_container is None:
+            print("Work loaded improperly; You may see unexpected behaviour")
+
         if load_chapters:
             self.load_chapters()
         
@@ -940,6 +960,34 @@ class Work:
             warnings.warn("This work is very big and might take a very long time to load")
         soup = BeautifulSoup(req.content, "lxml")
         return soup
+
+    def create_work(self, req):
+        """Request a web page and return a BeautifulSoup object.
+
+        Args:
+            url (str): Url to request
+
+        Returns:
+            bs4.BeautifulSoup: BeautifulSoup object representing the requested page's html
+        """
+
+        if len(req.content) > 650000:
+            warnings.warn("This work is very big and might take a very long time to load")
+        soup = BeautifulSoup(req.content, "lxml")
+        return soup
+
+    def request_raw(self, url):
+        """Request a web page and return a BeautifulSoup object.
+
+        Args:
+            url (str): Url to request
+
+        Returns:
+            bs4.BeautifulSoup: BeautifulSoup object representing the requested page's html
+        """
+
+        req = self.get(url)
+        return req
 
     @staticmethod
     def str_format(string):

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,6 @@
+Debugging Issues
+
+1. I had an error like this: "bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?"
+What do I do?
+
+A: Add this to the top of your code "import lxml" and make sure that lxml is installed 


### PR DESCRIPTION
Added extra checks to raise errors properly on locked and hidden works:
- locked works now raise `AO3.utils.AuthError` as described in documentation
- hidden works now raise `AO3.utils.HiddenWorkError`
- the 404 check no longer errors if the loaded page doesn't have an `h2.heading` tag (this will probably error somewhere else, but it makes adding new checks easier)
- added generic "Something went wrong" message for errors not covered separately